### PR TITLE
Add branch for focal as 'debian' is now on groovy.

### DIFF
--- a/package-model-R1.5.json
+++ b/package-model-R1.5.json
@@ -61,6 +61,13 @@
             "packageName": "regolith-desktop",
             "buildPath": "regolith-desktop",
             "upstreamTarball": "",
+            "packageBranch": "focal"
+        },
+        {
+            "gitRepoUrl": "https://github.com/regolith-linux/regolith-desktop.git",
+            "packageName": "regolith-desktop",
+            "buildPath": "regolith-desktop",
+            "upstreamTarball": "",
             "packageBranch": "ubuntu/bionic"
         },
         {


### PR DESCRIPTION
This change specifies that a package build of `regolith-desktop` should happen on the focal branch.  As a rule, the `debian` branch tracks the current release version of Ubuntu.