### PR TITLE
Remove github directory before building to avoid debuild error regard…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,6 +71,7 @@ package() {
 build() {
     print_banner "Building ${packageModel[packageName]}"
     cd $BUILD_DIR/${packageModel[buildPath]}
+    rm -Rf .github
     debuild -S -sa
     cd $BUILD_DIR
 }


### PR DESCRIPTION

Recent changes to add github actions conflict with debuild's rule that the source build dir doesn't contain extra files.  I'm not sure of a cleaner fix, I did some searching but it's also one of those things that's not easy to search for.  Ideally there would be a better way of fixing this but if not _shrugs_

```
***********************************************************
** Building regolith-i3xrocks-config
***********************************************************
 dpkg-buildpackage -us -uc -ui -S -sa
dpkg-buildpackage: info: source package regolith-i3xrocks-config
dpkg-buildpackage: info: source version 3.2.7-1
dpkg-buildpackage: info: source distribution bionic
dpkg-buildpackage: info: source changed by Regolith Linux <regolith.linux@gmail.com>
 dpkg-source --before-build .
 debian/rules clean
dh clean
   dh_clean
 dpkg-source -b .
dpkg-source: info: using source format '3.0 (quilt)'
dpkg-source: info: building regolith-i3xrocks-config using existing ./regolith-i3xrocks-config_3.2.7.orig.tar.gz
dpkg-source: info: local changes detected, the modified files are:
 regolith-i3xrocks-config/.github/workflows/test.yml
dpkg-source: error: aborting due to unexpected upstream changes, see /tmp/regolith-i3xrocks-config_3.2.7-1.diff.qQu8hN
dpkg-source: info: you can integrate the local changes with dpkg-source --commit
dpkg-buildpackage: error: dpkg-source -b . subprocess returned exit status 2
debuild: fatal error at line 1182:
dpkg-buildpackage -us -uc -ui -S -sa failed

```